### PR TITLE
#165370970 rename routers

### DIFF
--- a/server/routers/apiRouter.js
+++ b/server/routers/apiRouter.js
@@ -6,41 +6,41 @@ import editProfileController from '../controller/editProfileController';
 const router = express.Router();
 
 //customerController routers
-router.post('/signup', customerController.postUserSignup);
-router.post('/customer-login/:id', customerController.postUserLogin);
-router.post('/create-bank-account/:id', customerController.postCreateBankAccount);
+router.post('/auth/signup', customerController.postUserSignup);
+router.post('/auth/login/customers/:id', customerController.postUserLogin);
+router.post('/accounts/customers/:id', customerController.postCreateBankAccount);
 router.post('/contact/:id', customerController.postContactPage);
-router.get('/account-profile/:id', customerController.getAccountProfile);
-router.get('/transaction-history/:id', customerController.getTransactionHistory);
+router.get('/profile/customers/:id', customerController.getAccountProfile);
+router.get('/transactions/history/:id', customerController.getTransactionHistory);
 
 //adminStaffController routers
-router.get('/all', adminStaffController.getAllUserAccount);
-router.get('/savings-accounts', adminStaffController.getAllSavingsAccounts);
-router.get('/current-accounts', adminStaffController.getAllCurrentAccounts);
-router.get('/savings-accounts/:id', adminStaffController.getSavingsAccounts);
-router.get('/current-accounts/:id', adminStaffController.getCurrentAccounts);
-router.get('/admin-profile/:id', adminStaffController.getAdminProfile);
-router.get('/staff-profile/:id', adminStaffController.getStaffProfile);
+router.get('/users', adminStaffController.getAllUserAccount);
+router.get('/accounts/savings', adminStaffController.getAllSavingsAccounts);
+router.get('/accounts/current', adminStaffController.getAllCurrentAccounts);
+router.get('/accounts/savings/:id', adminStaffController.getSavingsAccounts);
+router.get('/accounts/current/:id', adminStaffController.getCurrentAccounts);
+router.get('/profile/admin/:id', adminStaffController.getAdminProfile);
+router.get('/profile/staff/:id', adminStaffController.getStaffProfile);
 router.get('/admin', adminStaffController.getAdminUserAccounts);
 router.get('/staff', adminStaffController.getStaffUserAccounts);
-router.delete('/savings-accounts/:id', adminStaffController.deleteSavingsAccount);
-router.delete('/current-accounts/:id', adminStaffController.deleteCurrentAccount)
+router.delete('/accounts/savings/:id', adminStaffController.deleteSavingsAccount);
+router.delete('/accounts/current/:id', adminStaffController.deleteCurrentAccount)
 router.delete('/admin/:id', adminStaffController.deleteAdminAccount);
 router.delete('/staff/:id', adminStaffController.deleteStaffAccount);
-router.patch('/savings-accounts/:id', adminStaffController.patchSavingsAccount);
-router.patch('/current-accounts/:id', adminStaffController.patchCurrentAccount);
+router.patch('/accounts/savings/:id', adminStaffController.patchSavingsAccount);
+router.patch('/accounts/current/:id', adminStaffController.patchCurrentAccount);
 router.patch('/admin/:id', adminStaffController.patchAdminAccount);
 router.patch('/staff/:id', adminStaffController.patchStaffAccount);
-router.post('/create-user-account', adminStaffController.postAdminCreateAccount);
-router.post('/admin-login/:id', adminStaffController.postAdminLogin);
-router.post('/staff-login/:id', adminStaffController.postStaffLogin);
-router.put('/current-accounts/:id', adminStaffController.updateCurrentAccount);
-router.put('/savings-accounts/:id', adminStaffController.updateSavingsAccount);
+router.post('/auth/personnel', adminStaffController.postAdminCreateAccount);
+router.post('/login/admin/:id', adminStaffController.postAdminLogin);
+router.post('/login/staff/:id', adminStaffController.postStaffLogin);
+router.put('/transactions/current/:id', adminStaffController.updateCurrentAccount);
+router.put('/transactions/savings/:id', adminStaffController.updateSavingsAccount);
 
 //editProfileController routers
-router.put('/customer-password/:id', editProfileController.updateCustomerPassword);
-router.put('/admin-password/:id', editProfileController.updateAdminPassword);
-router.put('/staff-password/:id', editProfileController.updateStaffPassword);
+router.put('/password/customers/:id', editProfileController.updateCustomerPassword);
+router.put('/password/admin/:id', editProfileController.updateAdminPassword);
+router.put('/password/staff/:id', editProfileController.updateStaffPassword);
 router.post('/uploads', editProfileController.postUploadPhoto);
 
 export default router;

--- a/server/test/adminStaff.test.js
+++ b/server/test/adminStaff.test.js
@@ -22,7 +22,7 @@ chai.use(chaiHttp);
     describe('api/v1/bank-accounts', () => {
         it('admin should get all accounts from memory', (done) => {
             chai.request(server)
-                .get('/all')
+                .get('/users')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -36,7 +36,7 @@ chai.use(chaiHttp);
         
         it('admin should get a speciific savings account from memory', (done) => {
             chai.request(server)
-                .get('/savings-accounts/:id')
+                .get('/accounts/savings/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -47,7 +47,7 @@ chai.use(chaiHttp);
 
         it('admin should get all savings account from memory', (done) => {
             chai.request(server)
-                 .get('/savings-accounts')
+                 .get('/accounts/savings')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -58,7 +58,7 @@ chai.use(chaiHttp);
 
         it('admin should get a speciific current account from memory', (done) => {
             chai.request(server)
-                 .get('/current-accounts/:id')
+                 .get('/accounts/current/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -69,7 +69,7 @@ chai.use(chaiHttp);
 
          it('admin should get all current account from memory', (done) => {
             chai.request(server)
-                 .get('/current-accounts')
+                 .get('/accounts/current')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -82,7 +82,7 @@ chai.use(chaiHttp);
     describe('api/v1/ delete a bank account', () => {
         it('admin should be able to delete a savings account', (done) => {
             chai.request(server)
-                .delete('/savings-accounts/:id')
+                .delete('/accounts/savings/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -93,7 +93,7 @@ chai.use(chaiHttp);
 
         it('admin should be able to delete a current account', (done) => {
             chai.request(server)
-                 .delete('/current-accounts/:id')
+                 .delete('/accounts/current/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -107,7 +107,7 @@ chai.use(chaiHttp);
 
         it('admin should be able to activate/deactivate a savings account', (done) => {
             chai.request(server)
-                .patch('/savings-accounts/:id')
+                .patch('/accounts/savings/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -118,7 +118,7 @@ chai.use(chaiHttp);
 
         it('admin should be able to activate/deactivate a current account', (done) => {
             chai.request(server)
-                 .patch('/current-accounts/:id')
+                 .patch('/accounts/current/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -144,7 +144,7 @@ chai.use(chaiHttp);
 
         it('admin should be able to create user(staff/admin) accounts', (done) => {
             chai.request(server)
-                .post('/create-user-account')
+                .post('/auth/personnel')
                 .send(createUserAccount)
                 .end((err, res) => {
                     expect(res.status).to.equal(200);          
@@ -159,7 +159,7 @@ chai.use(chaiHttp);
 
         it('should get an admin account profile', (done) => {
             chai.request(server)
-                 .get('/admin-profile/:id')
+                 .get('/profile/admin/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -170,7 +170,7 @@ chai.use(chaiHttp);
 
          it('should get a staff account profile', (done) => {
             chai.request(server)
-                 .get('/staff-profile/:id')
+                 .get('/profile/staff/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200)
                      expect(res.body).to.be.an('object');
@@ -216,7 +216,7 @@ chai.use(chaiHttp);
     
         it('Should login in a user(admin)', (done) => {
             chai.request(server)
-                .post('/admin-login/:id')
+                .post('/login/admin/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -227,7 +227,7 @@ chai.use(chaiHttp);
         
         it('Should login in a user(staff)', (done) => {
             chai.request(server)
-                .post('/staff-login/:id')
+                .post('/login/staff/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -312,7 +312,7 @@ chai.use(chaiHttp);
 
         it('staff should ba able to credit/debit a current account', (done) => {
            chai.request(server)
-                .put('/current-accounts/:id')
+                .put('/transactions/current/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -340,7 +340,7 @@ chai.use(chaiHttp);
         }
         it('staff should ba able to credit/debit a savings account', (done) => {
            chai.request(server)
-                .put('/savings-accounts/:id')
+                .put('/transactions/savings/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');

--- a/server/test/customer.test.js
+++ b/server/test/customer.test.js
@@ -26,7 +26,7 @@ chai.use(chaiHttp);
     
         it('Should create a customer', (done) => {
           chai.request(server)
-                .post('/signup')
+                .post('/auth/signup')
                 .send(signupTest)
                 .end((err, res,) => {
                     expect(res.status).to.equal(200);
@@ -50,7 +50,7 @@ chai.use(chaiHttp);
     
         it('Should login in a customer', (done) => {
             chai.request(server)
-                .post('/customer-login/:id')
+                .post('/auth/login/customers/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200)
                     expect(res.body).to.be.an('object');
@@ -91,7 +91,7 @@ chai.use(chaiHttp);
 
         it('Customer should be able to create account', (done) => {
             chai.request(server)
-                .post('/create-bank-account/:id')
+                .post('/accounts/customers/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200)
                     expect(res.body).to.be.an('object');
@@ -104,7 +104,7 @@ chai.use(chaiHttp);
 
         it('should get a customer account profile', (done) => {
             chai.request(server)
-                 .get('/account-profile/:id')
+                 .get('/profile/customers/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200)
                      expect(res.body).to.be.an('object');
@@ -146,7 +146,7 @@ chai.use(chaiHttp);
 
         it('Customer should be able to view their account transaction history', (done) => {
             chai.request(server)
-                .post('/transaction-history/:id')
+                .post('/transactions/history/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200)
                     expect(res.body).to.be.an('object');

--- a/server/test/editProfile.test.js
+++ b/server/test/editProfile.test.js
@@ -19,7 +19,7 @@ chai.use(chaiHttp);
     
         it('Customer should be able to reset account password', (done) => {
             chai.request(server)
-                .put('/customer-reset-password/:id')
+                .put('/password/customers/:id')
                 .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');
@@ -29,7 +29,7 @@ chai.use(chaiHttp);
 
         it('Admin should be able to reset account password', (done) => {
             chai.request(server)
-                 .put('/admin-reset-password/:id')
+                 .put('/password/admin/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -39,7 +39,7 @@ chai.use(chaiHttp);
 
          it('Staff should be able to reset account password', (done) => {
             chai.request(server)
-                 .put('/staff-reset-password/:id')
+                 .put('/password/staff/:id')
                  .end((err, res) => {
                      expect(res.status).to.equal(200);
                      expect(res.body).to.be.an('object');
@@ -54,7 +54,7 @@ chai.use(chaiHttp);
 
         it('should be able to upload an image', (done) => {
             chai.request(server)
-                 .put('/uploads')
+                 .post('/uploads')
                  .end((err, res) => {
                     expect(res.status).to.equal(200);
                     expect(res.body).to.be.an('object');


### PR DESCRIPTION
**What does this PR do?**
Rename API routes from verb to noun

**Description of Task to be completed?**
The following route should be changed

/customer-login
/create-bank-account
/account-profile/:id
/transaction-history
/all
/savings-accounts
/current-accounts
/savings-accounts/:id
/current-accounts/:id
/admin-profile/:id
/staff-profile/:id
savings-accounts/:id
/current-accounts
/savings-accounts/:id
/current-accounts
/create-user-account
/admin-login/:id
/staff-login/:id
/current-accounts/:id
/savings-accounts/:id
/customer-password/:id
/admin-password/:id
/staff-password/:id


**How should this be manually tested?**
Using Postman to check if the endpoints are working

**Any background context you want to provide?**
Non

**What are the relevant pivotal tracker stories?**
#165370970